### PR TITLE
Cosmetic cleanup and switch to advisory functions for ICF

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,15 +77,14 @@ to `M-w` like so:
 
 ## How Clipetty Works
 
-Clipetty does its magic by assigning the `clipetty-cut` function to Emacs'
-`interprogram-cut-function` variable, which is what happens when you activate
-`clipetty-mode`. When the mode is active, every time you kill a line or region
-Clipetty gets sent the content that is destined for the kill ring. The
-`clipetty-cut` function takes this content, converts it to base64, wraps it in
-an [ANSI OSC](https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences) 52 escape sequence, and then sends it to your terminal. Terminal
-programs which support OSC 52 commands will react to this by stripping off the
-escape sequence, decoding the base64 content, and then inserting the resulting
-string into the system clipboard.
+Clipetty does its magic by hooking Emacs' `interprogram-cut-function`, which is
+what happens when you activate `clipetty-mode`. When the mode is active, every
+time you kill a line or region Clipetty gets sent the content that is destined
+for the kill ring. The `clipetty-cut` function takes this content, converts it to
+base64, wraps it in an [ANSI OSC](https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences) 52 escape sequence, and then sends it to your
+terminal. Terminal programs which support OSC 52 commands will react to this by
+stripping off the escape sequence, decoding the base64 content, and then
+inserting the resulting string into the system clipboard.
 
 
 <a id="terminals"></a>

--- a/README.org
+++ b/README.org
@@ -72,15 +72,14 @@ to =M-w= like so:
 #+END_SRC
 
 ** How Clipetty Works
-Clipetty does its magic by assigning the =clipetty-cut= function to Emacs'
-=interprogram-cut-function= variable, which is what happens when you activate
-=clipetty-mode=. When the mode is active, every time you kill a line or region
-Clipetty gets sent the content that is destined for the kill ring. The
-=clipetty-cut= function takes this content, converts it to base64, wraps it in
-an [[https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences][ANSI OSC]] 52 escape sequence, and then sends it to your terminal. Terminal
-programs which support OSC 52 commands will react to this by stripping off the
-escape sequence, decoding the base64 content, and then inserting the resulting
-string into the system clipboard.
+Clipetty does its magic by hooking Emacs' =interprogram-cut-function=, which is
+what happens when you activate =clipetty-mode=. When the mode is active, every
+time you kill a line or region Clipetty gets sent the content that is destined
+for the kill ring. The =clipetty-cut= function takes this content, converts it to
+base64, wraps it in an [[https://en.wikipedia.org/wiki/ANSI_escape_code#Escape_sequences][ANSI OSC]] 52 escape sequence, and then sends it to your
+terminal. Terminal programs which support OSC 52 commands will react to this by
+stripping off the escape sequence, decoding the base64 content, and then
+inserting the resulting string into the system clipboard.
 
 ** Terminals that Support OSC Clipboard Operations
 :PROPERTIES:

--- a/clipetty.el
+++ b/clipetty.el
@@ -116,18 +116,20 @@ frame's environment."
 (defun clipetty--make-dcs (string &optional screen)
   "Return STRING, wrapped in a Tmux flavored Device Control String.
 Return STRING, wrapped in a GNU screen flavored DCS, if SCREEN is non-nil."
-  (let ((dcs-start clipetty--tmux-dcs-start))
-    (when screen (setq dcs-start clipetty--screen-dcs-start))
+  (let ((dcs-start (if screen
+		       clipetty--screen-dcs-start
+		     clipetty--tmux-dcs-start)))
     (concat dcs-start string clipetty--dcs-end)))
 
 (defun clipetty--dcs-wrap (string tmux term ssh-tty)
   "Return STRING wrapped in an appropriate DCS if necessary.
 The arguments TMUX, TERM, and SSH-TTY should come from the selected
 frame's environment."
-  (let ((screen (if term (string-match-p clipetty-screen-regexp term) nil))
-        (dcs    string))
-    (cond (screen (setq dcs (clipetty--make-dcs string t)))
-          (tmux   (setq dcs (clipetty--make-dcs string))))
+  (let* ((screen (if term (string-match-p clipetty-screen-regexp term) nil))
+         (dcs
+          (cond (screen (clipetty--make-dcs string t))
+                (tmux   (clipetty--make-dcs string))
+                (t      string))))
     (if ssh-tty (if clipetty-assume-nested-mux dcs string) dcs)))
 
 (defun clipetty--osc (string &optional encode)

--- a/clipetty.el
+++ b/clipetty.el
@@ -48,35 +48,31 @@
 Nesting is the practice of running a terminal multiplexer inside
 a terminal multiplexer, which is what you'd be doing if you ran
 tmux both locally and on remote hosts you SSH into."
-  :type 'boolean
-  :group 'clipetty)
+  :type 'boolean)
 
 (defcustom clipetty-tmux-ssh-tty "tmux show-environment SSH_TTY"
   "The command we send to tmux to determine the SSH_TTY.
 This default assumes that tmux is on your PATH.  If tmux lives
 elsewhere for you, or it is named something else, you can change
 it here."
-  :type 'string
-  :group 'clipetty)
+  :type 'string)
 
 (defcustom clipetty-screen-regexp "^screen"
   "This regexp is matched against TERM to test for the presence of GNU screen.
 If you've configured GNU screen to use an unusual terminal type,
 you can change this regular expression so Clipetty will recognize
 when you're running in screen."
-  :type 'regexp
-  :group 'clipetty)
+  :type 'regexp)
 
 (defcustom clipetty-tmux-ssh-tty-regexp "^SSH_TTY=\\([^\n]+\\)"
   "This regexp is used to capture the SSH_TTY from output of tmux.
 Unless you're inventing a new method for determining the SSH_TTY, after
 a detach / re-attach it's unlikely you'll need to change this."
-  :type 'regexp
-  :group 'clipetty)
+  :type 'regexp)
 
 (defconst clipetty--max-cut 74994
   "The maximum length of a string you can send to the clipboard via OSC52.
-The max OSC 52 message is 10,000 bytes.  This means we can
+The max OSC 52 message is 100,000 bytes.  This means we can
 support base64 encoded strings of up to 74,994 bytes long.")
 
 (defconst clipetty--screen-dcs-start "\eP"
@@ -173,7 +169,6 @@ Optionally base64 encode it first if you specify non-nil for ENCODE."
 (define-minor-mode clipetty-mode
   "Minor mode to send every kill from a TTY frame to the system clipboard."
   :lighter " Clp"
-  :group 'clipetty
   :init-value nil
   :global nil
   (make-local-variable 'interprogram-cut-function)
@@ -186,8 +181,7 @@ Optionally base64 encode it first if you specify non-nil for ENCODE."
 ;;;###autoload
 (define-globalized-minor-mode global-clipetty-mode
   clipetty-mode
-  (lambda () (clipetty-mode +1))
-  :group 'clipetty)
+  (lambda () (clipetty-mode +1)))
 
 ;;;###autoload
 (defun clipetty-kill-ring-save ()


### PR DESCRIPTION
Incorporate some feedback from Stefan Monnier.

In addition to some cosmetic cleanup, this PR also changes the way we deal with the `interprogram-cut-function`. Instead of directly manipulating it, we now use the advisory functions `add-function` and `remove-function` to hook it.

