### PR TITLE
Fix: NOT append to tty

### DIFF
--- a/clipetty.el
+++ b/clipetty.el
@@ -145,7 +145,7 @@ Optionally base64 encode it first if you specify non-nil for ENCODE."
          (clipetty--dcs-wrap string tmux term ssh-tty)
          nil
          (clipetty--tty ssh-tty tmux)
-         t
+         nil
          0)
       (message "Selection too long to send to terminal %d" (length string))
       (sit-for 1))))


### PR DESCRIPTION
Issue: spudlyo/clipetty#20

I noticed that append to tty causes the "Permission denied" as below - It occurred in Termux (not tmux), and the same issue occurred in emacs 26.3 on Termux. Therefore, I changed a parameter in `write-region` function at the `clipetty--emit`. I hope that this PR solves your issues also!

```
$ echo test > `tty`
test
$ echo test >> `tty`
Permission denied
```

This PR will close spudlyo/clipetty#20 .

