### PR TITLE
Check for tmux before checking for screen.

### DIFF
--- a/clipetty.el
+++ b/clipetty.el
@@ -124,8 +124,8 @@ The arguments TMUX, TERM, and SSH-TTY should come from the selected
 frame's environment."
   (let* ((screen (if term (string-match-p clipetty-screen-regexp term) nil))
          (dcs
-          (cond (screen (clipetty--make-dcs string t))
-                (tmux   (clipetty--make-dcs string))
+          (cond (tmux   (clipetty--make-dcs string))
+                (screen (clipetty--make-dcs string t))
                 (t      string))))
     (if ssh-tty (if clipetty-assume-nested-mux dcs string) dcs)))
 


### PR DESCRIPTION
By default, tmux will re-use the screen-* TERM values, which will
cause DCS sequences to not get added.  The presence of the TMUX
environment variable is a stronger signal anyways, so first check
whether we're running in tmux, and secondly whether we're running
under screen.