### PR TITLE
Add Windows Terminal to support list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ inserting the resulting string into the system clipboard.
 -   [hterm](https://hterm.org) (Javascript)
 -   [st](https://st.suckless.org/) (Unix)
 -   [mlterm](https://sourceforge.net/projects/mlterm/) (Unix, Windows, macOS)
+-   [Windows Terminal](https://github.com/microsoft/terminal) (Windows)
 
 This is not an exhaustive list, these are just the ones I know about. Submit a
 PR if you know of any I missed.


### PR DESCRIPTION
Using this now with clipetty in my current WSL tty environment and can confirm it works well.

Support was added in https://github.com/microsoft/terminal/pull/5823