### PR TITLE
Add mosh<=1.4.0 support + Fix local kitty

### DIFF
--- a/clipetty.el
+++ b/clipetty.el
@@ -103,12 +103,13 @@ Return nil if tmux is unable to locate the environment variable"
   "Return which TTY we should send our OSC payload to.
 Both the SSH-TTY and TMUX arguments should come from the selected
 frame's environment."
-  (if (not ssh-tty)
-      (terminal-name)
-    (if tmux
-        (let ((tmux-ssh-tty (clipetty--get-tmux-ssh-tty)))
-          (if tmux-ssh-tty tmux-ssh-tty terminal-name))
-      terminal-name)))
+  (let ((terminal-name "/dev/tty"))
+   (if (not ssh-tty)
+       (terminal-name)
+     (if tmux
+         (let ((tmux-ssh-tty (clipetty--get-tmux-ssh-tty)))
+           (if tmux-ssh-tty tmux-ssh-tty terminal-name))
+       terminal-name))))
 
 (defun clipetty--make-dcs (string &optional screen)
   "Return STRING, wrapped in a Tmux flavored Device Control String.

--- a/clipetty.el
+++ b/clipetty.el
@@ -141,14 +141,14 @@ Optionally base64 encode it first if you specify non-nil for ENCODE."
         (term    (getenv "TERM" (selected-frame)))
         (ssh-tty (getenv "SSH_TTY" (selected-frame))))
     (if (<= (length string) clipetty--max-cut)
-        (write-region
-         (clipetty--dcs-wrap string tmux term ssh-tty)
-         nil
-         (clipetty--tty ssh-tty tmux)
-         t
-         0)
-      (message "Selection too long to send to terminal %d" (length string))
-      (sit-for 1))))
+        (progn
+         (write-region
+          (clipetty--dcs-wrap string tmux term ssh-tty)
+          nil
+          (clipetty--tty ssh-tty tmux)
+          t
+          0)
+         (sit-for 0.1)))))
 
 (defun clipetty-cut (orig-fun string)
   "If in a terminal frame, convert STRING to a series of OSC 52 messages.

--- a/clipetty.el
+++ b/clipetty.el
@@ -107,8 +107,8 @@ frame's environment."
       (terminal-name)
     (if tmux
         (let ((tmux-ssh-tty (clipetty--get-tmux-ssh-tty)))
-          (if tmux-ssh-tty tmux-ssh-tty ssh-tty))
-      ssh-tty)))
+          (if tmux-ssh-tty tmux-ssh-tty terminal-name))
+      terminal-name)))
 
 (defun clipetty--make-dcs (string &optional screen)
   "Return STRING, wrapped in a Tmux flavored Device Control String.


### PR DESCRIPTION
- Fix: mosh clipboard buffer flush bug due to inactive sit-for in clippety--emit 
- Fall back on /dev/tty instead of ssh_tty (also fixes local kitty undefined terminal-name error)

Tested with: 
-   kitty + mosh
-   kitty + ssh
-   local kitty

I don't use tmux myself it would be great if someone could confirm this is working in tmux